### PR TITLE
Position footer to bottom of screen always

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -36,7 +36,7 @@ const { title, description } = Astro.props;
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
 <link rel="icon" type="image/svg+xml" href="/favicon.png" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,11 +42,15 @@ body {
 	color: var(--black);
 	font-size: 20px;
 	line-height: 1.7;
+	display: flex;
+	flex-direction: column;
+	min-height: 100dvh;
 }
 main {
 	max-width: calc(100% - 0.75em);
 	margin: auto;
 	padding: 1em;
+	flex-grow: 1;
 }
 h1,
 h2,


### PR DESCRIPTION
This updates some CSS so that the footer will always be at the bottom of the screen. 
This is much more noticeable on mobile but also on [/glowlichenfix](https://www.ceilingash.link/glowlichenfix)

Old:
<img width="1917" height="736" alt="image" src="https://github.com/user-attachments/assets/5939fc4b-ec3e-4b1c-853a-e8821301bcf4" />

New:
<img width="1917" height="745" alt="image" src="https://github.com/user-attachments/assets/210bc0d0-6463-4278-af3f-23722bd5ef98" />

